### PR TITLE
Check CF_HOME every time and check .cf/config.json existance

### DIFF
--- a/cf-ps1.sh
+++ b/cf-ps1.sh
@@ -1,8 +1,5 @@
 #! /usr/bin/env bash
 
-CF_PS1_HOME="${CF_HOME:-$HOME}"
-CF_PS1_API_ENDPOINT_FOUNDATION_POSITION="${CF_PS1_API_ENDPOINT_FOUNDATION_POSITION:-false}"
-
 if [ -n "$ZSH_VERSION" ]; then
   CF_PS1_SHELL="zsh"
 elif [ -n "$BASH_VERSION" ]; then
@@ -33,6 +30,8 @@ _cf_ps1_get_foundation_name() {
 }
 
 _cf_ps1_update() {
+    CF_PS1_HOME="${CF_HOME:-$HOME}"
+    CF_PS1_API_ENDPOINT_FOUNDATION_POSITION="${CF_PS1_API_ENDPOINT_FOUNDATION_POSITION:-false}"
     CF_PS1_CF_CONFIG="${CF_PS1_HOME}/.cf/config.json"
 
     _cf_ps1_get_foundation_name

--- a/cf-ps1.sh
+++ b/cf-ps1.sh
@@ -33,6 +33,9 @@ _cf_ps1_update() {
     CF_PS1_HOME="${CF_HOME:-$HOME}"
     CF_PS1_API_ENDPOINT_FOUNDATION_POSITION="${CF_PS1_API_ENDPOINT_FOUNDATION_POSITION:-false}"
     CF_PS1_CF_CONFIG="${CF_PS1_HOME}/.cf/config.json"
+    if [ ! -f "$CF_PS1_CF_CONFIG" ]; then
+        return
+    fi
 
     _cf_ps1_get_foundation_name
     CF_PS1_ORG="$(jq -r '.OrganizationFields.Name' < $CF_PS1_CF_CONFIG)"


### PR DESCRIPTION
## About checking CF_HOME every time
### Current Problem
Because variable `CF_PS1_HOME` is defined beginning of cf-ps1.sh and not redefined after initialization,  modified `CF_HOME` environment variable does not affect cf-ps1.

### This PR
Function `cf_ps1` updates `CF_PS1_HOME` on every call.

```console
$ cat ~/.cf/config.json
{"AuthorizationEndpoint":"https://myfoundation"}
$ cat another/.cf/config.json
{"AuthorizationEndpoint":"https://anotherfoundation"}
$ cfon
(cf| myfoundation:null:null) $ CF_HOME=another
(cf| anotherfoundation:null:null) $
```

## About checking .cf/config.json cf
### Current Problem
If `${CF_HOME}/.cf/config.json` does not exist, function `cf_ps1` exits on error with following message.
```
_cf_ps1_get_foundation_name:1: no such file or directory: /home/user/.cf/config.json                       
_cf_ps1_update:4: no such file or directory: /home/user/.cf/config.json
_cf_ps1_update:5: no such file or directory: /home/user/.cf/config.json
```

### This PR
`cf_ps1` outputs no error message when `${CF_HOME}/.cf/config.json` does not exist.